### PR TITLE
RFC: Changing number of guards & a minor usability fix

### DIFF
--- a/pathsim.py
+++ b/pathsim.py
@@ -27,8 +27,8 @@ class TorOptions:
     # given by #define ROUTER_MAX_AGE (60*60*48) in or.h    
     router_max_age = 60*60*48    
     
-    num_guards = 3
-    min_num_guards = 2
+    num_guards = 1
+    min_num_guards = 1
     guard_expiration_min = 60*24*3600 # min time until guard removed from list
     guard_expiration_max = 90*24*3600 # max time until guard removed from list 
     default_bwweightscale = 10000   
@@ -1671,7 +1671,7 @@ consensuses')
         help='indicates the number of adversarial exits to add')
     simulate_parser.add_argument('--other_network_modifier', default=None,
         help='class to modify network, argument syntax: module.class-argstring')
-    simulate_parser.add_argument('--num_guards', type=int, default=3,
+    simulate_parser.add_argument('--num_guards', type=int, default=1,
         help='indicates size of client guard list')
     simulate_parser.add_argument('--guard_expiration', type=int, default=60,
         help='indicates time in days until one-month period during which guard\

--- a/pathsim.py
+++ b/pathsim.py
@@ -1647,7 +1647,7 @@ ServerDescriptor) instead of the analagous stem classes')
         help='stores the network state files to use')
     simulate_parser.add_argument('--num_samples', type=int, default=1,
         help='number of simulations to execute')
-    simulate_parser.add_argument('--trace_file', default=None,
+    simulate_parser.add_argument('--trace_file', default="in/users2-processed.traces.pickle",
         help='name of files containing the user traces')
     simulate_parser.add_argument('--user_model', default='simple=600',
         help='user model to build out of traces, with standard trace file one \


### PR DESCRIPTION
This pull request consists of two commits:
- It reduces the number of guards from three to one.
- It sets a default path for the argument `trace_file`.

Let me know what you think.
